### PR TITLE
Switch to using strongly typed messages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnetSockets"
 uuid = "28ddc128-e2b5-11e9-14fc-f7f8bf0be62e"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -11,5 +11,5 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 julia = "1.3"
-Fjage = "0.4"
+Fjage = "0.6"
 Reexport = "1.2"

--- a/src/Messages.jl
+++ b/src/Messages.jl
@@ -1,96 +1,847 @@
-export AbnormalTerminationNtf, AgentLifecycleNtf, AgentStartNtf, AgentTerminationNtf
-export FailureNtf, RefuseRsp, CapabilityListRsp, CapabilityReq, ParamChangeNtf
-export DatagramReq, DatagramNtf, ClearReq, DatagramCancelReq
-export DatagramDeliveryNtf, DatagramFailureNtf, DatagramProgressNtf
-export TxFrameReq, TxRawFrameReq, TxFrameStartNtf, TxFrameNtf, RxFrameStartNtf, RxFrameNtf
-export BadFrameNtf, CollisionNtf, TxJanusFrameReq, RxJanusFrameNtf, FecDecodeReq
-export TxBasebandSignalReq, RxBasebandSignalNtf, RecordBasebandSignalReq, GetPreambleSignalReq
-export AddressAllocReq, AddressAllocRsp, AddressResolutionReq, AddressResolutionRsp
-export RangeReq, BeaconReq, RangeNtf, InterrogationNtf, RespondReq
-export ReservationReq, ReservationCancelReq, ReservationAcceptReq, TxAckReq
-export ReservationRsp, ReservationStatusNtf, LinkStatusNtf
-export EditRouteReq, GetRouteReq, RouteRsp, RouteChangeNtf, RouteTraceReq, RouteTraceNtf
-export DatagramTraceReq, RouteDiscoveryReq, RouteDiscoveryNtf
-export RemoteTextReq, RemoteFileGetReq, RemoteFilePutReq, RemoteExecReq
-export RemoteTextNtf, RemoteFileNtf, RemoteSuccessNtf, RemoteFailureNtf
-export AddScheduledSleepReq, RemoveScheduledSleepReq, GetSleepScheduleReq, SleepScheduleRsp, WakeFromSleepNtf
-export ClearStateReq, SaveStateReq
+# This file is largely generated automatically from the Unet message definitions.
+# However, there is some customization (see comments marked as "manual editing"),
+# and so updating it will involve a careful merge.
+
+abstract type RouteInfo <: Fjage.Message end
+abstract type DatagramReq <: Fjage.Message end
+abstract type BasebandSignal <: Fjage.Message end
+abstract type TxFrameReq <: DatagramReq end
+abstract type RemoteMessageReq <: DatagramReq end
+abstract type AgentLifecycleNtf <: Fjage.Message end
+abstract type DatagramNtf <: Fjage.Message end
+abstract type RxFrameNtf <: DatagramNtf end
+abstract type DatagramTransmissionNtf <: Fjage.Message end
+abstract type DatagramFailureNtf <: Fjage.Message end
+abstract type DatagramDeliveryNtf <: Fjage.Message end
+abstract type RemoteMessageNtf <: DatagramNtf end
+
+export RouteRsp
+Fjage.@message "org.arl.unet.net.RouteRsp" :INFORM struct RouteRsp <: RouteInfo
+  op::Union{Symbol,Nothing} = nothing
+  uuid::Union{String,Nothing} = nothing
+  to::Union{Int32,Nothing} = nothing
+  nextHop::Union{Int32,Nothing} = nothing
+  link::Union{String,Nothing} = nothing
+  reliability::Union{Bool,Nothing} = nothing
+  hops::Union{Int32,Nothing} = nothing
+  dataRate::Union{Float32,Nothing} = nothing
+  MTU::Union{Int32,Nothing} = nothing
+  RTU::Union{Int32,Nothing} = nothing
+  metric::Union{Float32,Nothing} = nothing
+  enabled::Union{Bool,Nothing} = nothing
+end
+
+export CapabilityListRsp
+Fjage.@message "org.arl.unet.CapabilityListRsp" :INFORM struct CapabilityListRsp
+  capSet::Vector{String} = []
+end
+
+export ScheduledTaskRsp
+Fjage.@message "org.arl.unet.scheduler.ScheduledTaskRsp" :INFORM struct ScheduledTaskRsp
+  tasks::Vector{Any} = []
+end
+
+export RefuseRsp
+Fjage.@message "org.arl.unet.RefuseRsp" :REFUSE struct RefuseRsp
+  reason::Union{String,Nothing} = nothing
+end
+
+export ReservationRsp
+Fjage.@message "org.arl.unet.mac.ReservationRsp" :AGREE struct ReservationRsp
+  estimatedStartTime::Union{Int64,Nothing} = nothing
+end
+
+export AddressResolutionRsp
+Fjage.@message "org.arl.unet.addr.AddressResolutionRsp" :INFORM struct AddressResolutionRsp
+  address::Int32 = -1
+  name::Union{String,Nothing} = nothing
+end
+
+export AddressAllocRsp
+Fjage.@message "org.arl.unet.addr.AddressAllocRsp" :INFORM struct AddressAllocRsp
+  address::Int32 = -1
+end
+
+export GetRouteReq
+Fjage.@message "org.arl.unet.net.GetRouteReq" :REQUEST struct GetRouteReq
+  to::Int32 = -1
+  all::Bool = false
+end
+
+export DatagramTraceReq
+Fjage.@message "org.arl.unet.net.DatagramTraceReq" :REQUEST struct DatagramTraceReq <: DatagramReq
+  data::Union{Vector{UInt8},Nothing} = nothing
+  to::Int32 = 0
+  from::Int32 = 0
+  protocol::Int32 = 0
+  reliability::Union{Bool,Nothing} = nothing
+  robustness::Symbol = :NORMAL
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+  shortcircuit::Bool = true
+  route::Union{String,Nothing} = nothing
+  progress::Bool = false
+end
+
+export RouteDiscoveryReq
+Fjage.@message "org.arl.unet.net.RouteDiscoveryReq" :REQUEST struct RouteDiscoveryReq
+  to::Int32 = -1
+  maxHops::Int32 = 3
+  count::Int32 = 3
+  interval::Float32 = 20.0
+end
+
+export RouteTraceReq
+Fjage.@message "org.arl.unet.net.RouteTraceReq" :REQUEST struct RouteTraceReq
+  to::Int32 = -1
+end
+
+export EditRouteReq
+Fjage.@message "org.arl.unet.net.EditRouteReq" :REQUEST struct EditRouteReq <: RouteInfo
+  op::Union{Symbol,Nothing} = nothing
+  uuid::Union{String,Nothing} = nothing
+  to::Union{Int32,Nothing} = nothing
+  nextHop::Union{Int32,Nothing} = nothing
+  link::Union{String,Nothing} = nothing
+  reliability::Union{Bool,Nothing} = nothing
+  hops::Union{Int32,Nothing} = nothing
+  dataRate::Union{Float32,Nothing} = nothing
+  MTU::Union{Int32,Nothing} = nothing
+  RTU::Union{Int32,Nothing} = nothing
+  metric::Union{Float32,Nothing} = nothing
+  enabled::Union{Bool,Nothing} = nothing
+end
+
+export GetPreambleSignalReq
+Fjage.@message "org.arl.unet.bb.GetPreambleSignalReq" :REQUEST struct GetPreambleSignalReq
+  preamble::Int32 = -1
+end
+
+export TxBasebandSignalReq
+Fjage.@message "org.arl.unet.bb.TxBasebandSignalReq" :REQUEST struct TxBasebandSignalReq <: BasebandSignal
+  txStartTime::Union{Int64,Nothing} = nothing
+  wakeup::Bool = false
+  powerLevel::Union{Float32,Nothing} = nothing
+  signal::Union{Union{Vector{Complex{Float32}},Vector{Float32}},Nothing} = nothing
+  fc::Float32 = -1.0
+  fs::Float32 = -1.0
+  channels::Int32 = 1
+  preamble::Int32 = 0
+  ### begin manual editing
+  function TxBasebandSignalReq(txStartTime, wakeup, powerLevel, signal::AbstractVecOrMat, fc, fs, channels, preamble, messageID, performative, sender, recipient, inReplyTo, sentAt)
+    eltype(signal) <: Complex && fc == 0 && error("fc must be non-zero for complex (baseband) signals")
+    if eltype(signal) <: Real
+      fc > 0 && error("fc must be zero for real (passband) signals")
+      fc = 0f0
+    end
+    channels = size(signal, 2)
+    msg = new(txStartTime, wakeup, powerLevel, nothing, fc, fs, channels, preamble, messageID, performative, sender, recipient, inReplyTo, sentAt)
+    msg.signal = signal
+    msg
+  end
+  ### end manual editing
+end
+
+export RecordBasebandSignalReq
+Fjage.@message "org.arl.unet.bb.RecordBasebandSignalReq" :REQUEST struct RecordBasebandSignalReq
+  recStartTime::Union{Int64,Nothing} = nothing
+  recLength::Union{Int32,Nothing} = nothing
+end
+
+export CapabilityReq
+Fjage.@message "org.arl.unet.CapabilityReq" :QUERY_IF struct CapabilityReq
+  cap::Union{String,Nothing} = nothing
+end
+
+export SleepReq
+Fjage.@message "org.arl.unet.scheduler.SleepReq" :REQUEST struct SleepReq
+end
+
+export AddScheduledTaskReq
+Fjage.@message "org.arl.unet.scheduler.AddScheduledTaskReq" :REQUEST struct AddScheduledTaskReq
+  scheduler::Union{String,Nothing} = nothing
+  minute::String = "*"
+  hour::String = "*"
+  date::String = "*"
+  month::String = "*"
+  year::String = "*"
+  day::String = "*"
+  cmd::Union{String,Nothing} = nothing
+  shell::Union{String,Nothing} = nothing
+  persist::Bool = true
+  repeat::Bool = true
+end
+
+export RemoveScheduledTaskReq
+Fjage.@message "org.arl.unet.scheduler.RemoveScheduledTaskReq" :REQUEST struct RemoveScheduledTaskReq
+  id::Union{String,Nothing} = nothing
+end
+
+export StayAwakeReq
+Fjage.@message "org.arl.unet.scheduler.StayAwakeReq" :REQUEST struct StayAwakeReq
+  seconds::Int32 = 0
+end
+
+export GetScheduleReq
+Fjage.@message "org.arl.unet.scheduler.GetScheduleReq" :REQUEST struct GetScheduleReq
+end
+
+export SaveStateReq
+Fjage.@message "org.arl.unet.state.SaveStateReq" :REQUEST struct SaveStateReq
+  stateName::Union{String,Nothing} = nothing
+  agentID::Union{String,Nothing} = nothing
+  ignore::Vector{String} = []
+end
+
+export ClearStateReq
+Fjage.@message "org.arl.unet.state.ClearStateReq" :REQUEST struct ClearStateReq
+end
+
+export FecDecodeReq
+Fjage.@message "org.arl.unet.phy.FecDecodeReq" :REQUEST struct FecDecodeReq
+  type::Int32 = 2
+  rxStartTime::Union{Int64,Nothing} = nothing
+  metrics::Union{Vector{Float32},Nothing} = nothing
+end
+
+export TxFrameReq
+Fjage.@message "org.arl.unet.phy.TxFrameReq" :REQUEST struct TxFrameReq <: TxFrameReq
+  type::Int32 = 1
+  timestamped::Bool = false
+  txStartTime::Union{Int64,Nothing} = nothing
+  wakeup::Bool = false
+  data::Union{Vector{UInt8},Nothing} = nothing
+  to::Int32 = 0
+  from::Int32 = 0
+  protocol::Int32 = 0
+  reliability::Union{Bool,Nothing} = nothing
+  robustness::Symbol = :NORMAL
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+  shortcircuit::Bool = true
+  route::Union{String,Nothing} = nothing
+  progress::Bool = false
+end
+
+export TxSWiG1FrameReq
+Fjage.@message "org.arl.unet.phy.TxSWiG1FrameReq" :REQUEST struct TxSWiG1FrameReq <: TxFrameReq
+  appData::Int64 = 0
+  type::Int32 = 3
+  timestamped::Bool = false
+  txStartTime::Union{Int64,Nothing} = nothing
+  wakeup::Bool = false
+  data::Union{Vector{UInt8},Nothing} = nothing
+  to::Int32 = 0
+  from::Int32 = 0
+  protocol::Int32 = 0
+  reliability::Union{Bool,Nothing} = nothing
+  robustness::Symbol = :NORMAL
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+  shortcircuit::Bool = true
+  route::Union{String,Nothing} = nothing
+  progress::Bool = false
+end
+
+export TxJanusFrameReq
+Fjage.@message "org.arl.unet.phy.TxJanusFrameReq" :REQUEST struct TxJanusFrameReq <: TxFrameReq
+  classUserID::Int32 = 42
+  appType::Int32 = 0
+  appData::Int64 = 0
+  mobility::Union{Bool,Nothing} = nothing
+  canForward::Union{Bool,Nothing} = nothing
+  txRxFlag::Bool = true
+  reservationDuration::Float32 = 0.0
+  repeatInterval::Float32 = 0.0
+  type::Int32 = 3
+  timestamped::Bool = false
+  txStartTime::Union{Int64,Nothing} = nothing
+  wakeup::Bool = false
+  data::Union{Vector{UInt8},Nothing} = nothing
+  to::Int32 = 0
+  from::Int32 = 0
+  protocol::Int32 = 0
+  reliability::Union{Bool,Nothing} = nothing
+  robustness::Symbol = :NORMAL
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+  shortcircuit::Bool = true
+  route::Union{String,Nothing} = nothing
+  progress::Bool = false
+end
+
+export DatagramReq
+Fjage.@message "org.arl.unet.DatagramReq" :REQUEST struct DatagramReq <: DatagramReq
+  data::Union{Vector{UInt8},Nothing} = nothing
+  to::Int32 = 0
+  from::Int32 = 0
+  protocol::Int32 = 0
+  reliability::Union{Bool,Nothing} = nothing
+  robustness::Symbol = :NORMAL
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+  shortcircuit::Bool = true
+  route::Union{String,Nothing} = nothing
+  progress::Bool = false
+end
+
+export ReservationAcceptReq
+Fjage.@message "org.arl.unet.mac.ReservationAcceptReq" :REQUEST struct ReservationAcceptReq
+  id::Union{String,Nothing} = nothing
+  payload::Union{Vector{UInt8},Nothing} = nothing
+end
+
+export ReservationReq
+Fjage.@message "org.arl.unet.mac.ReservationReq" :REQUEST struct ReservationReq
+  to::Int32 = 0
+  duration::Float32 = 0.0
+  payload::Union{Vector{UInt8},Nothing} = nothing
+  reliable::Bool = false
+  ttl::Union{Float32,Nothing} = nothing
+  priority::Symbol = :NORMAL
+  startTime::Union{Int64,Nothing} = nothing
+end
+
+export TxAckReq
+Fjage.@message "org.arl.unet.mac.TxAckReq" :REQUEST struct TxAckReq
+  requestID::Union{String,Nothing} = nothing
+  payload::Union{Vector{UInt8},Nothing} = nothing
+end
+
+export ReservationCancelReq
+Fjage.@message "org.arl.unet.mac.ReservationCancelReq" :REQUEST struct ReservationCancelReq
+  id::Union{String,Nothing} = nothing
+end
+
+export LinkTuneReq
+Fjage.@message "org.arl.unet.link.LinkTuneReq" :REQUEST struct LinkTuneReq
+  to::Int32 = -1
+end
+
+export LinkSchemeReq
+Fjage.@message "org.arl.unet.link.LinkSchemeReq" :REQUEST struct LinkSchemeReq
+  to::Int32 = -1
+  schemeCode::Union{String,Nothing} = nothing
+  powerLevel::Union{Int32,Nothing} = nothing
+  test::Int32 = 0
+end
+
+export CancelReq
+Fjage.@message "org.arl.unet.CancelReq" :REQUEST struct CancelReq
+  id::Union{String,Nothing} = nothing
+end
+
+export ClearReq
+Fjage.@message "org.arl.unet.ClearReq" :REQUEST struct ClearReq
+end
+
+export AddressAllocReq
+Fjage.@message "org.arl.unet.addr.AddressAllocReq" :REQUEST struct AddressAllocReq
+  name::Union{String,Nothing} = nothing
+  addressSize::Union{Int32,Nothing} = nothing
+end
+
+export AddressResolutionReq
+Fjage.@message "org.arl.unet.addr.AddressResolutionReq" :REQUEST struct AddressResolutionReq
+  name::Union{String,Nothing} = nothing
+end
+
+export RangeReq
+Fjage.@message "org.arl.unet.localization.RangeReq" :REQUEST struct RangeReq
+  to::Int32 = -1
+  requestLocation::Bool = false
+  data::Union{Vector{UInt8},Nothing} = nothing
+end
+
+export RespondReq
+Fjage.@message "org.arl.unet.localization.RespondReq" :REQUEST struct RespondReq
+  to::Int32 = 0
+  type::Int32 = 0
+  rxStartTime::Int64 = 0
+  data::Union{Vector{UInt8},Nothing} = nothing
+end
+
+export BeaconReq
+Fjage.@message "org.arl.unet.localization.BeaconReq" :REQUEST struct BeaconReq
+  type::Int32 = 0
+  to::Int32 = 0
+  txLocation::Bool = false
+  data::Union{Vector{UInt8},Nothing} = nothing
+end
+
+export RemoteFilePutReq
+Fjage.@message "org.arl.unet.remote.RemoteFilePutReq" :REQUEST struct RemoteFilePutReq
+  to::Int32 = -1
+  data::Union{Vector{UInt8},Nothing} = nothing
+  filename::Union{String,Nothing} = nothing
+  localFilename::Union{String,Nothing} = nothing
+  resume::Bool = true
+  progress::Bool = false
+  credentials::Union{String,Nothing} = nothing
+  priority::Symbol = :NORMAL
+end
+
+export RemoteFileGetReq
+Fjage.@message "org.arl.unet.remote.RemoteFileGetReq" :REQUEST struct RemoteFileGetReq
+  to::Int32 = -1
+  filename::Union{String,Nothing} = nothing
+  localFilename::Union{String,Nothing} = nothing
+  credentials::Union{String,Nothing} = nothing
+  progress::Bool = false
+  resume::Bool = true
+  priority::Symbol = :NORMAL
+end
+
+export RemoteTextReq
+Fjage.@message "org.arl.unet.remote.RemoteTextReq" :REQUEST struct RemoteTextReq <: RemoteMessageReq
+  text::Union{String,Nothing} = nothing
+  mimeType::String = "application/x-chat"
+  remoteRecipient::Union{String,Nothing} = nothing
+  mailbox::Union{String,Nothing} = nothing
+  messageClass::Union{String,Nothing} = nothing
+  data::Union{Vector{UInt8},Nothing} = nothing
+  to::Int32 = 0
+  from::Int32 = 0
+  protocol::Int32 = 0
+  reliability::Union{Bool,Nothing} = nothing
+  robustness::Symbol = :NORMAL
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+  shortcircuit::Bool = true
+  route::Union{String,Nothing} = nothing
+  progress::Bool = false
+end
+
+export RemoteMessageReq
+Fjage.@message "org.arl.unet.remote.RemoteMessageReq" :REQUEST struct RemoteMessageReq <: RemoteMessageReq
+  mimeType::String = "application/octet-stream"
+  remoteRecipient::Union{String,Nothing} = nothing
+  mailbox::Union{String,Nothing} = nothing
+  messageClass::Union{String,Nothing} = nothing
+  data::Union{Vector{UInt8},Nothing} = nothing
+  to::Int32 = 0
+  from::Int32 = 0
+  protocol::Int32 = 0
+  reliability::Union{Bool,Nothing} = nothing
+  robustness::Symbol = :NORMAL
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+  shortcircuit::Bool = true
+  route::Union{String,Nothing} = nothing
+  progress::Bool = false
+end
+
+export RemoteExecReq
+Fjage.@message "org.arl.unet.remote.RemoteExecReq" :REQUEST struct RemoteExecReq <: RemoteMessageReq
+  command::Union{String,Nothing} = nothing
+  credentials::Union{String,Nothing} = nothing
+  mimeType::String = "application/x-command"
+  remoteRecipient::Union{String,Nothing} = nothing
+  mailbox::Union{String,Nothing} = nothing
+  messageClass::Union{String,Nothing} = nothing
+  data::Union{Vector{UInt8},Nothing} = nothing
+  to::Int32 = 0
+  from::Int32 = 0
+  protocol::Int32 = 0
+  reliability::Union{Bool,Nothing} = nothing
+  robustness::Symbol = :NORMAL
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+  shortcircuit::Bool = true
+  route::Union{String,Nothing} = nothing
+  progress::Bool = false
+end
+
+export DatagramDeliveryNtf
+Fjage.@message "org.arl.unet.DatagramDeliveryNtf" :INFORM struct DatagramDeliveryNtf <: DatagramDeliveryNtf
+end
+
+export ParamChangeNtf
+Fjage.@message "org.arl.unet.ParamChangeNtf" :INFORM struct ParamChangeNtf
+  paramValues::Dict{String,Any} = Dict{String,Any}()
+  readonly::Vector{String} = []
+  index::Int32 = -1
+end
+
+export RouteDiscoveryNtf
+Fjage.@message "org.arl.unet.net.RouteDiscoveryNtf" :INFORM struct RouteDiscoveryNtf
+  to::Int32 = 0
+  nextHop::Int32 = -1
+  link::Union{String,Nothing} = nothing
+  reliability::Bool = true
+  hops::Int32 = 0
+  route::Union{Vector{Int32},Nothing} = nothing
+end
+
+export RouteChangeNtf
+Fjage.@message "org.arl.unet.net.RouteChangeNtf" :INFORM struct RouteChangeNtf <: RouteInfo
+  op::Union{Symbol,Nothing} = nothing
+  uuid::Union{String,Nothing} = nothing
+  to::Union{Int32,Nothing} = nothing
+  nextHop::Union{Int32,Nothing} = nothing
+  link::Union{String,Nothing} = nothing
+  reliability::Union{Bool,Nothing} = nothing
+  hops::Union{Int32,Nothing} = nothing
+  dataRate::Union{Float32,Nothing} = nothing
+  MTU::Union{Int32,Nothing} = nothing
+  RTU::Union{Int32,Nothing} = nothing
+  metric::Union{Float32,Nothing} = nothing
+  enabled::Union{Bool,Nothing} = nothing
+end
+
+export RouteTraceNtf
+Fjage.@message "org.arl.unet.net.RouteTraceNtf" :INFORM struct RouteTraceNtf
+  to::Int32 = -1
+  trace::Union{Vector{Int32},Nothing} = nothing
+end
+
+export DetectionNtf
+Fjage.@message "org.arl.unet.bb.DetectionNtf" :INFORM struct DetectionNtf
+  rxStartTime::Union{Int64,Nothing} = nothing
+  rxDuration::Union{Int32,Nothing} = nothing
+  preamble::Int32 = -1
+  detector::Float32 = 0.0
+end
+
+export RxBasebandSignalNtf
+Fjage.@message "org.arl.unet.bb.RxBasebandSignalNtf" :INFORM struct RxBasebandSignalNtf <: BasebandSignal
+  rxStartTime::Union{Int64,Nothing} = nothing
+  location::Union{Vector{Float64},Nothing} = nothing
+  rssi::Union{Float32,Nothing} = nothing
+  preambleLength::Int32 = 0
+  signal::Union{Union{Vector{Complex{Float32}},Vector{Float32}},Nothing} = nothing
+  fc::Float32 = -1.0
+  fs::Float32 = -1.0
+  channels::Int32 = 1
+  preamble::Int32 = 0
+end
+
+export TxEndNtf
+Fjage.@message "org.arl.unet.bb.TxEndNtf" :INFORM struct TxEndNtf
+  txStartTime::Union{Int64,Nothing} = nothing
+  preamble::Int32 = -1
+  location::Union{Vector{Float64},Nothing} = nothing
+end
+
+export TxStartNtf
+Fjage.@message "org.arl.unet.bb.TxStartNtf" :INFORM struct TxStartNtf
+  txStartTime::Union{Int64,Nothing} = nothing
+  txDuration::Union{Int32,Nothing} = nothing
+  preamble::Int32 = -1
+end
+
+export ProgressNtf
+Fjage.@message "org.arl.unet.ProgressNtf" :INFORM struct ProgressNtf
+  peer::Int32 = 0
+  transferred::Int64 = 0
+  total::Int64 = 0
+  incoming::Bool = false
+  filename::Union{String,Nothing} = nothing
+end
+
+export AgentTerminationNtf
+Fjage.@message "org.arl.unet.AgentTerminationNtf" :INFORM struct AgentTerminationNtf <: AgentLifecycleNtf
+  agentClassName::Union{String,Nothing} = nothing
+  containerName::Union{String,Nothing} = nothing
+end
+
+export AbnormalTerminationNtf
+Fjage.@message "org.arl.unet.AbnormalTerminationNtf" :INFORM struct AbnormalTerminationNtf <: AgentLifecycleNtf
+  exception::Union{Any,Nothing} = nothing
+  agentClassName::Union{String,Nothing} = nothing
+  containerName::Union{String,Nothing} = nothing
+end
+
+export AgentLifecycleNtf
+Fjage.@message "org.arl.unet.AgentLifecycleNtf" :INFORM struct AgentLifecycleNtf <: AgentLifecycleNtf
+  agentClassName::Union{String,Nothing} = nothing
+  containerName::Union{String,Nothing} = nothing
+end
+
+export WakeFromSleepNtf
+Fjage.@message "org.arl.unet.scheduler.WakeFromSleepNtf" :INFORM struct WakeFromSleepNtf
+end
+
+export AboutToSleepNtf
+Fjage.@message "org.arl.unet.scheduler.AboutToSleepNtf" :INFORM struct AboutToSleepNtf
+  scheduledNextWakeupTime::Int64 = 0
+end
+
+export BadFrameNtf
+Fjage.@message "org.arl.unet.phy.BadFrameNtf" :INFORM struct BadFrameNtf
+  rxStartTime::Int64 = 0
+  location::Union{Vector{Float64},Nothing} = nothing
+  data::Union{Vector{UInt8},Nothing} = nothing
+  metrics::Union{Vector{Float32},Nothing} = nothing
+  type::Int32 = -1
+  rssi::Float32 = NaN
+end
+
+export RxFrameNtf
+Fjage.@message "org.arl.unet.phy.RxFrameNtf" :INFORM struct RxFrameNtf <: RxFrameNtf
+  type::Int32 = 1
+  txStartTime::Union{Int64,Nothing} = nothing
+  rxStartTime::Union{Int64,Nothing} = nothing
+  location::Union{Vector{Float64},Nothing} = nothing
+  bits::Int32 = 0
+  errors::Union{Int32,Nothing} = nothing
+  rssi::Float32 = NaN
+  cfo::Float32 = NaN
+  metrics::Union{Vector{Float32},Nothing} = nothing
+  data::Union{Vector{UInt8},Nothing} = nothing
+  from::Int32 = 0
+  to::Int32 = 0
+  protocol::Int32 = 0
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+end
+
+export TxFrameStartNtf
+Fjage.@message "org.arl.unet.phy.TxFrameStartNtf" :INFORM struct TxFrameStartNtf
+  txStartTime::Union{Int64,Nothing} = nothing
+  txDuration::Union{Int32,Nothing} = nothing
+  type::Int32 = -1
+end
+
+export RxSWiG1FrameNtf
+Fjage.@message "org.arl.unet.phy.RxSWiG1FrameNtf" :INFORM struct RxSWiG1FrameNtf <: RxFrameNtf
+  appData::Int64 = 0
+  type::Int32 = 3
+  txStartTime::Union{Int64,Nothing} = nothing
+  rxStartTime::Union{Int64,Nothing} = nothing
+  location::Union{Vector{Float64},Nothing} = nothing
+  bits::Int32 = 0
+  errors::Union{Int32,Nothing} = nothing
+  rssi::Float32 = NaN
+  cfo::Float32 = NaN
+  metrics::Union{Vector{Float32},Nothing} = nothing
+  data::Union{Vector{UInt8},Nothing} = nothing
+  from::Int32 = 0
+  to::Int32 = 0
+  protocol::Int32 = 0
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+end
+
+export CollisionNtf
+Fjage.@message "org.arl.unet.phy.CollisionNtf" :INFORM struct CollisionNtf
+  type::Int32 = -1
+  rxStartTime::Union{Int64,Nothing} = nothing
+  detector::Float32 = 0.0
+end
+
+export RxJanusFrameNtf
+Fjage.@message "org.arl.unet.phy.RxJanusFrameNtf" :INFORM struct RxJanusFrameNtf <: RxFrameNtf
+  classUserID::Int32 = 0
+  appType::Int32 = 0
+  appData::Int64 = 0
+  mobility::Bool = false
+  canForward::Bool = false
+  txRxFlag::Bool = false
+  reservationDuration::Float32 = 0.0
+  repeatInterval::Float32 = 0.0
+  type::Int32 = 3
+  txStartTime::Union{Int64,Nothing} = nothing
+  rxStartTime::Union{Int64,Nothing} = nothing
+  location::Union{Vector{Float64},Nothing} = nothing
+  bits::Int32 = 0
+  errors::Union{Int32,Nothing} = nothing
+  rssi::Float32 = NaN
+  cfo::Float32 = NaN
+  metrics::Union{Vector{Float32},Nothing} = nothing
+  data::Union{Vector{UInt8},Nothing} = nothing
+  from::Int32 = 0
+  to::Int32 = 0
+  protocol::Int32 = 0
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+end
+
+export TxFrameNtf
+Fjage.@message "org.arl.unet.phy.TxFrameNtf" :INFORM struct TxFrameNtf <: DatagramTransmissionNtf
+  txStartTime::Union{Int64,Nothing} = nothing
+  type::Int32 = -1
+  location::Union{Vector{Float64},Nothing} = nothing
+end
+
+export RxFrameStartNtf
+Fjage.@message "org.arl.unet.phy.RxFrameStartNtf" :INFORM struct RxFrameStartNtf
+  rxStartTime::Union{Int64,Nothing} = nothing
+  rxDuration::Union{Int32,Nothing} = nothing
+  type::Int32 = -1
+  detector::Float32 = 0.0
+end
+
+export ReservationStatusNtf
+Fjage.@message "org.arl.unet.mac.ReservationStatusNtf" :INFORM struct ReservationStatusNtf
+  to::Int32 = 0
+  from::Int32 = -1
+  status::Union{Symbol,Nothing} = nothing
+  payload::Union{Vector{UInt8},Nothing} = nothing
+end
+
+export ReservationNtf
+Fjage.@message "org.arl.unet.mac.ReservationNtf" :INFORM struct ReservationNtf
+  id::Union{String,Nothing} = nothing
+  duration::Float32 = 0.0
+  startTime::Union{Int64,Nothing} = nothing
+end
+
+export LinkSchemeNtf
+Fjage.@message "org.arl.unet.link.LinkSchemeNtf" :INFORM struct LinkSchemeNtf
+  to::Int32 = 0
+  schemeCode::Union{String,Nothing} = nothing
+  powerLevel::Union{Int32,Nothing} = nothing
+end
+
+export LinkPerformanceNtf
+Fjage.@message "org.arl.unet.link.LinkPerformanceNtf" :INFORM struct LinkPerformanceNtf
+  to::Int32 = 0
+  schemeCode::Union{String,Nothing} = nothing
+  powerLevel::Union{Int32,Nothing} = nothing
+  bits::Int32 = 0
+  errors::Vector{Int32} = []
+  rssi::Vector{Float32} = []
+end
+
+export LinkStatusNtf
+Fjage.@message "org.arl.unet.link.LinkStatusNtf" :INFORM struct LinkStatusNtf
+  to::Int32 = 0
+  up::Union{Bool,Nothing} = nothing
+  quality::Union{Float32,Nothing} = nothing
+end
+
 export TestReportNtf
+Fjage.@message "org.arl.unet.TestReportNtf" :INFORM struct TestReportNtf
+  report::Union{Vector{String},Nothing} = nothing
+  pass::Bool = true
+end
 
-global AbnormalTerminationNtf = MessageClass(@__MODULE__, "org.arl.unet.AbnormalTerminationNtf")
-global AgentLifecycleNtf = MessageClass(@__MODULE__, "org.arl.unet.AgentLifecycleNtf")
-global AgentStartNtf = MessageClass(@__MODULE__, "org.arl.unet.AgentStartNtf")
-global AgentTerminationNtf = MessageClass(@__MODULE__, "org.arl.unet.AgentTerminationNtf")
-global FailureNtf = MessageClass(@__MODULE__, "org.arl.unet.FailureNtf")
-global RefuseRsp = MessageClass(@__MODULE__, "org.arl.unet.RefuseRsp")
-global CapabilityListRsp = MessageClass(@__MODULE__, "org.arl.unet.CapabilityListRsp")
-global CapabilityReq = MessageClass(@__MODULE__, "org.arl.unet.CapabilityReq")
-global ParamChangeNtf = MessageClass(@__MODULE__, "org.arl.unet.ParamChangeNtf")
-global DatagramReq = AbstractMessageClass(@__MODULE__, "org.arl.unet.DatagramReq")
-global DatagramNtf = AbstractMessageClass(@__MODULE__, "org.arl.unet.DatagramNtf")
-global ClearReq = MessageClass(@__MODULE__, "org.arl.unet.ClearReq")
-global DatagramCancelReq = MessageClass(@__MODULE__, "org.arl.unet.DatagramCancelReq")
-global DatagramDeliveryNtf = MessageClass(@__MODULE__, "org.arl.unet.DatagramDeliveryNtf")
-global DatagramFailureNtf = MessageClass(@__MODULE__, "org.arl.unet.DatagramFailureNtf")
-global DatagramProgressNtf = MessageClass(@__MODULE__, "org.arl.unet.DatagramProgressNtf")
-global TxFrameReq = MessageClass(@__MODULE__, "org.arl.unet.phy.TxFrameReq", DatagramReq)
-global TxRawFrameReq = MessageClass(@__MODULE__, "org.arl.unet.phy.TxRawFrameReq")
-global TxFrameStartNtf = MessageClass(@__MODULE__, "org.arl.unet.phy.TxFrameStartNtf")
-global TxFrameNtf = MessageClass(@__MODULE__, "org.arl.unet.phy.TxFrameNtf")
-global RxFrameStartNtf = MessageClass(@__MODULE__, "org.arl.unet.phy.RxFrameStartNtf")
-global RxFrameNtf = MessageClass(@__MODULE__, "org.arl.unet.phy.RxFrameNtf", DatagramNtf)
-global BadFrameNtf = MessageClass(@__MODULE__, "org.arl.unet.phy.BadFrameNtf")
-global CollisionNtf = MessageClass(@__MODULE__, "org.arl.unet.phy.CollisionNtf")
-global TxJanusFrameReq = MessageClass(@__MODULE__, "org.arl.unet.phy.TxJanusFrameReq")
-global RxJanusFrameNtf = MessageClass(@__MODULE__, "org.arl.unet.phy.RxJanusFrameNtf")
-global FecDecodeReq = MessageClass(@__MODULE__, "org.arl.unet.phy.FecDecodeReq")
-BasebandSignal = AbstractMessageClass(@__MODULE__, "org.arl.unet.bb.BasebandSignal")
-global TxBasebandSignalReq = MessageClass(@__MODULE__, "org.arl.unet.bb.TxBasebandSignalReq", BasebandSignal)
-global RxBasebandSignalNtf = MessageClass(@__MODULE__, "org.arl.unet.bb.RxBasebandSignalNtf", BasebandSignal)
-global RecordBasebandSignalReq = MessageClass(@__MODULE__, "org.arl.unet.bb.RecordBasebandSignalReq")
-global GetPreambleSignalReq = MessageClass(@__MODULE__, "org.arl.unet.bb.GetPreambleSignalReq")
-global RangeReq = MessageClass(@__MODULE__, "org.arl.unet.localization.RangeReq")
-global BeaconReq = MessageClass(@__MODULE__, "org.arl.unet.localization.BeaconReq")
-global RangeNtf = MessageClass(@__MODULE__, "org.arl.unet.localization.RangeNtf")
-global InterrogationNtf = MessageClass(@__MODULE__, "org.arl.unet.localization.InterrogationNtf")
-global RespondReq = MessageClass(@__MODULE__, "org.arl.unet.localization.RespondReq")
-global AddressAllocReq = MessageClass(@__MODULE__, "org.arl.unet.addr.AddressAllocReq")
-global AddressAllocRsp = MessageClass(@__MODULE__, "org.arl.unet.addr.AddressAllocRsp")
-global AddressResolutionReq = MessageClass(@__MODULE__, "org.arl.unet.addr.AddressResolutionReq")
-global AddressResolutionRsp = MessageClass(@__MODULE__, "org.arl.unet.addr.AddressResolutionRsp")
-global ReservationReq = MessageClass(@__MODULE__, "org.arl.unet.mac.ReservationReq")
-global ReservationAcceptReq = MessageClass(@__MODULE__, "org.arl.unet.mac.ReservationAcceptReq")
-global ReservationCancelReq = MessageClass(@__MODULE__, "org.arl.unet.mac.ReservationCancelReq")
-global TxAckReq = MessageClass(@__MODULE__, "org.arl.unet.mac.TxAckReq")
-global ReservationRsp = MessageClass(@__MODULE__, "org.arl.unet.mac.ReservationRsp")
-global ReservationStatusNtf = MessageClass(@__MODULE__, "org.arl.unet.mac.ReservationStatusNtf")
-global LinkStatusNtf = MessageClass(@__MODULE__, "org.arl.unet.link.LinkStatusNtf")
-global EditRouteReq = MessageClass(@__MODULE__, "org.arl.unet.net.EditRouteReq")
-global GetRouteReq = MessageClass(@__MODULE__, "org.arl.unet.net.GetRouteReq")
-global RouteRsp = MessageClass(@__MODULE__, "org.arl.unet.net.RouteRsp")
-global RouteChangeNtf = MessageClass(@__MODULE__, "org.arl.unet.net.RouteChangeNtf")
-global RouteTraceReq = MessageClass(@__MODULE__, "org.arl.unet.net.RouteTraceReq")
-global RouteTraceNtf = MessageClass(@__MODULE__, "org.arl.unet.net.RouteTraceNtf")
-global DatagramTraceReq = MessageClass(@__MODULE__, "org.arl.unet.net.DatagramTraceReq")
-global RouteDiscoveryReq = MessageClass(@__MODULE__, "org.arl.unet.net.RouteDiscoveryReq")
-global RouteDiscoveryNtf = MessageClass(@__MODULE__, "org.arl.unet.net.RouteDiscoveryNtf")
-global RemoteTextReq = MessageClass(@__MODULE__, "org.arl.unet.remote.RemoteTextReq")
-global RemoteFileGetReq = MessageClass(@__MODULE__, "org.arl.unet.remote.RemoteFileGetReq")
-global RemoteFilePutReq = MessageClass(@__MODULE__, "org.arl.unet.remote.RemoteFilePutReq")
-global RemoteExecReq = MessageClass(@__MODULE__, "org.arl.unet.remote.RemoteExecReq")
-global RemoteTextNtf = MessageClass(@__MODULE__, "org.arl.unet.remote.RemoteTextNtf")
-global RemoteFileNtf = MessageClass(@__MODULE__, "org.arl.unet.remote.RemoteFileNtf")
-global RemoteSuccessNtf = MessageClass(@__MODULE__, "org.arl.unet.remote.RemoteSuccessNtf")
-global RemoteFailureNtf = MessageClass(@__MODULE__, "org.arl.unet.remote.RemoteFailureNtf")
-global AddScheduledSleepReq = MessageClass(@__MODULE__, "org.arl.unet.scheduler.AddScheduledSleepReq")
-global RemoveScheduledSleepReq = MessageClass(@__MODULE__, "org.arl.unet.scheduler.RemoveScheduledSleepReq")
-global GetSleepScheduleReq = MessageClass(@__MODULE__, "org.arl.unet.scheduler.GetSleepScheduleReq")
-global SleepScheduleRsp = MessageClass(@__MODULE__, "org.arl.unet.scheduler.SleepScheduleRsp")
-global WakeFromSleepNtf = MessageClass(@__MODULE__, "org.arl.unet.scheduler.WakeFromSleepNtf")
-global SaveStateReq = MessageClass(@__MODULE__, "org.arl.unet.state.SaveStateReq")
-global ClearStateReq = MessageClass(@__MODULE__, "org.arl.unet.state.ClearStateReq")
-global TestReportNtf = MessageClass(@__MODULE__, "org.arl.unet.TestReportNtf")
+export AgentStartNtf
+Fjage.@message "org.arl.unet.AgentStartNtf" :INFORM struct AgentStartNtf <: AgentLifecycleNtf
+  services::Union{Vector{String},Nothing} = nothing
+  agentClassName::Union{String,Nothing} = nothing
+  containerName::Union{String,Nothing} = nothing
+end
 
-function __init__()
-  Fjage.registermessages()
+export DatagramFailureNtf
+Fjage.@message "org.arl.unet.DatagramFailureNtf" :INFORM struct DatagramFailureNtf <: DatagramFailureNtf
+end
+
+export DatagramTransmissionNtf
+Fjage.@message "org.arl.unet.DatagramTransmissionNtf" :INFORM struct DatagramTransmissionNtf <: DatagramTransmissionNtf
+end
+
+export FailureNtf
+Fjage.@message "org.arl.unet.FailureNtf" :FAILURE struct FailureNtf
+  reason::Union{String,Nothing} = nothing
+end
+
+export InterrogationNtf
+Fjage.@message "org.arl.unet.localization.InterrogationNtf" :INFORM struct InterrogationNtf
+  from::Int32 = 0
+  to::Int32 = 0
+  type::Int32 = 0
+  rxStartTime::Int64 = 0
+  data::Union{Vector{UInt8},Nothing} = nothing
+  responded::Bool = false
+end
+
+export BearingNtf
+Fjage.@message "org.arl.unet.localization.BearingNtf" :INFORM struct BearingNtf
+  azimuth::Union{Float64,Nothing} = nothing
+  elevation::Union{Float64,Nothing} = nothing
+  worldAzimuth::Union{Float64,Nothing} = nothing
+  worldElevation::Union{Float64,Nothing} = nothing
+  rxStartTime::Union{Int64,Nothing} = nothing
+  pitch::Union{Float64,Nothing} = nothing
+  roll::Union{Float64,Nothing} = nothing
+  yaw::Union{Float64,Nothing} = nothing
+  location::Union{Vector{Float64},Nothing} = nothing
+end
+
+export PeerLocationNtf
+Fjage.@message "org.arl.unet.localization.PeerLocationNtf" :INFORM struct PeerLocationNtf
+  peer::Int32 = -1
+  peerLocation::Union{Vector{Float64},Nothing} = nothing
+  rxStartTime::Union{Int64,Nothing} = nothing
+  location::Union{Vector{Float64},Nothing} = nothing
+end
+
+export RangeNtf
+Fjage.@message "org.arl.unet.localization.RangeNtf" :INFORM struct RangeNtf
+  from::Int32 = 0
+  to::Int32 = 0
+  rxStartTime::Union{Int64,Nothing} = nothing
+  range::Union{Float32,Nothing} = nothing
+  offset::Union{Int64,Nothing} = nothing
+  location::Union{Vector{Float64},Nothing} = nothing
+  peerLocation::Union{Vector{Float64},Nothing} = nothing
+  data::Union{Vector{UInt8},Nothing} = nothing
+end
+
+export DatagramNtf
+Fjage.@message "org.arl.unet.DatagramNtf" :INFORM struct DatagramNtf <: DatagramNtf
+  data::Union{Vector{UInt8},Nothing} = nothing
+  from::Int32 = 0
+  to::Int32 = 0
+  protocol::Int32 = 0
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+end
+
+export SystemNtf
+Fjage.@message "org.arl.unet.SystemNtf" :INFORM struct SystemNtf
+  level::Symbol = :WARNING
+  description::Union{String,Nothing} = nothing
+  details::Union{Any,Nothing} = nothing
+end
+
+export RemoteFailureNtf
+Fjage.@message "org.arl.unet.remote.RemoteFailureNtf" :INFORM struct RemoteFailureNtf <: DatagramFailureNtf
+  reason::Union{String,Nothing} = nothing
+end
+
+export RemoteMessageNtf
+Fjage.@message "org.arl.unet.remote.RemoteMessageNtf" :INFORM struct RemoteMessageNtf <: RemoteMessageNtf
+  mimeType::String = "application/octet-stream"
+  data::Union{Vector{UInt8},Nothing} = nothing
+  from::Int32 = 0
+  to::Int32 = 0
+  protocol::Int32 = 0
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+end
+
+export RemoteSuccessNtf
+Fjage.@message "org.arl.unet.remote.RemoteSuccessNtf" :INFORM struct RemoteSuccessNtf <: DatagramDeliveryNtf
+end
+
+export RemoteTextNtf
+Fjage.@message "org.arl.unet.remote.RemoteTextNtf" :INFORM struct RemoteTextNtf <: RemoteMessageNtf
+  text::Union{String,Nothing} = nothing
+  mimeType::String = "application/x-chat"
+  data::Union{Vector{UInt8},Nothing} = nothing
+  from::Int32 = 0
+  to::Int32 = 0
+  protocol::Int32 = 0
+  ttl::Float32 = NaN
+  priority::Symbol = :NORMAL
+end
+
+export RemoteFileNtf
+Fjage.@message "org.arl.unet.remote.RemoteFileNtf" :INFORM struct RemoteFileNtf
+  from::Int32 = -1
+  data::Union{Vector{UInt8},Nothing} = nothing
+  filename::Union{String,Nothing} = nothing
+  transferDuration::Float32 = NaN
+end
+
+export BasebandSignal
+Fjage.@message "org.arl.unet.bb.BasebandSignal" :INFORM struct BasebandSignal <: BasebandSignal
+  signal::Union{Union{Vector{Complex{Float32}},Vector{Float32}},Nothing} = nothing
+  fc::Float32 = -1.0
+  fs::Float32 = -1.0
+  channels::Int32 = 1
+  preamble::Int32 = 0
 end

--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -10,7 +10,7 @@ function Base.setproperty!(msg::BasebandSignal, p::Symbol, v::AbstractVecOrMat)
     msg.channels = size(v, 2)
     v = vec(transpose(v))
     if eltype(v) == Complex{Float64}
-      v = ComplexF32.(v)
+      v = convert(Array{ComplexF32}, v)
     elseif eltype(v) == Float64
       v = Float32.(v)
     end

--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -1,0 +1,19 @@
+# special handling of message properties
+
+function Base.getproperty(msg::BasebandSignal, p::Symbol)
+  p === :signal && return transpose(reshape(getfield(msg, :signal), msg.channels, :))
+  getfield(msg, p)
+end
+
+function Base.setproperty!(msg::BasebandSignal, p::Symbol, v::AbstractVecOrMat)
+  if p === :signal
+    msg.channels = size(v, 2)
+    v = vec(transpose(v))
+    if eltype(v) == Complex{Float64}
+      v = ComplexF32.(v)
+    elseif eltype(v) == Float64
+      v = Float32.(v)
+    end
+  end
+  setfield!(msg, p, v)
+end

--- a/src/UnetSockets.jl
+++ b/src/UnetSockets.jl
@@ -12,6 +12,11 @@ export isclosed, getgateway, host, unbind, isbound, connect, disconnect, isconne
 export getlocalprotocol, getremoteaddress, getremoteprotocol, settimeout, gettimeout, cancel
 
 include("Messages.jl")
+include("Properties.jl")
+
+function __init__()
+  Fjage.registermessages()
+end
 
 "Well-known addresses."
 module Address


### PR DESCRIPTION
Fjage 0.5 introduced strongly typed messages. This PR defines strongly typed Unet messages and adds some convenience APIs to deal with signals.

The convenience APIs include a constructor for `TxBasebandSignalReq` that automatically converts `Float64` signals to `Float32`, if needed, and populates `channels` and `fc` based on the dimensionality of the signal array passed in. It also adds property getters and setters for `signal` to aid with the same. This allows us to do something like:
```julia
using UnetSockets, SignalAnalysis

# create multidimensional passband signal
x = [cw(22000, 1, 192000) cw(24000, 1, 192000) cw(26000, 1, 192000)] |> real
msg = TxBasebandSignalReq(signal=x)

# get back multidimensional signal
msg.signal
```
